### PR TITLE
Fix LayerEditor onChange handler

### DIFF
--- a/src/components/LayerEditor.jsx
+++ b/src/components/LayerEditor.jsx
@@ -99,7 +99,9 @@ export default function LayerEditor({ onExport }) {
           <select
             style={{ padding: '0.4rem 0.6rem', fontSize: '1rem', borderRadius: 6, border: '1px solid #ccc' }}
             value={selected[layer]}
-            onChange={(e) => setSelected((prev) => ({{ ...prev, [layer]: e.target.value }}))}
+            onChange={(e) =>
+              setSelected((prev) => ({ ...prev, [layer]: e.target.value }))
+            }
           >
             {layers[layer].map((file) => (
               <option key={file} value={file}>


### PR DESCRIPTION
## Summary
- fix `setSelected` call in LayerEditor

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887fed8163c8329b3345ce9daaec1f5