### PR TITLE
Fix onChange handler in LayerEditor

### DIFF
--- a/src/components/LayerEditor.jsx
+++ b/src/components/LayerEditor.jsx
@@ -99,9 +99,7 @@ export default function LayerEditor({ onExport }) {
           <select
             style={{ padding: '0.4rem 0.6rem', fontSize: '1rem', borderRadius: 6, border: '1px solid #ccc' }}
             value={selected[layer]}
-            onChange={(e) =>
-              setSelected((prev) => ({ ...prev, [layer]: e.target.value }))
-            }
+            onChange={(e) => setSelected(prev => ({ ...prev, [layer]: e.target.value }))}
           >
             {layers[layer].map((file) => (
               <option key={file} value={file}>


### PR DESCRIPTION
## Summary
- update the select onChange handler to use concise syntax

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688808cd13ec8329a439d61b4eb21d6e